### PR TITLE
docs: mark broken link(s) in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ You can check out the GitHub Explore website [at github.com/explore](https://git
 * [Understanding the GitHub flow](https://guides.github.com/introduction/flow/)
 * [How to use GitHub branches](https://www.youtube.com/watch?v=H5GJfcp3p4Q&feature=youtu.be)
 * [Interactive Git training materials](https://githubtraining.github.io/training-manual/#/01_getting_ready_for_class)
-* [GitHub's Learning Lab](https://lab.github.com/)
+* GitHub's Learning Lab (BROKEN LINK: https://lab.github.com/) — replacement: [GitHub Skills](https://skills.github.com/)
 * [Education community forum](https://education.github.community/)
 * [GitHub community forum](https://github.community/)


### PR DESCRIPTION
Checked README.md links; https://lab.github.com/ no longer resolves. Marked as BROKEN LINK and provided replacement (https://skills.github.com/). Added .gitignore to ignore .DS_Store.